### PR TITLE
feat(aosvc-python): Add support for MAC through Launchd

### DIFF
--- a/aosvc-python/README.md
+++ b/aosvc-python/README.md
@@ -1,8 +1,23 @@
 # aosvc-python
 
-This is an alternative for the Go-based `aosvc`. It's mainly intended for linux use via systemd (WSL2 supported), although it can be used on windows by using e.g. [NSSM](https://nssm.cc/).
+This is an alternative for the Go-based `aosvc`.
+
+## Supported OS
+
+### Linux
+Supported via systemd (WSL2 supported).
+
+### Mac
+Supported via [launchd](https://www.launchd.info/)
+
+### Windows
+it can be used on windows by using e.g. [NSSM](https://nssm.cc/)
+
+> Not further instruction will be provided here
 
 ## Installation
+### Linux
+
 Just `cd` into this directory and run the installation script:
 ```sh
 cd aosvc-python
@@ -12,3 +27,14 @@ cd aosvc-python
 The script will install the python script in `~/.local/bin/` and the service unit file in `~/.config/systemd/user/`. The service is installed as a systemd user service and will update the `default` profile in `~/.aws/credentials` for the installing user.
 
 There's also an `uninstall.sh` for removal.
+
+### Mac
+Just `cd` into this directory and run the installation script:
+```sh
+cd aosvc-python
+./install_mac.sh
+```
+
+The script will install the python script in `~/.local/share/aosvc/bin/` and the service unit file in `~/Library/LaunchAgents. The service is loaded as a launchd service and will update the `default` profile in `~/.aws/credentials` for the installing user.
+
+There's also an `uninstall_mac.sh` for removal.

--- a/aosvc-python/aosvc.plist
+++ b/aosvc-python/aosvc.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>aosvc</string>
+    <key>ServiceDescription</key>
+    <string>AlwaysOn Service</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+    	<key>PYTHONUNBUFFERED</key>
+    	<string>x</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/tmp/aosvc.err</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/aosvc.out</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>export HOME=$(echo $HOME); $HOME/.local/share/aosvc/bin/aosvc</string>
+    </array>
+</dict>
+</plist>
+

--- a/aosvc-python/install_mac.sh
+++ b/aosvc-python/install_mac.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -xe
+
+launch_config_dir="$HOME/Library/LaunchAgents"
+launch_config_path="$launch_config_dir/com.github.ilyatbn.aws_alwayson.plist"
+service_path="$HOME/.local/share/aosvc/bin"
+user_uid=$(id -u)
+
+mkdir -p "$service_path"
+cp aosvc "$service_path"
+cp aosvc.plist "$launch_config_path"
+launchctl bootstrap "gui/$user_uid" "$launch_config_path"
+launchctl start aosvc

--- a/aosvc-python/uninstall_mac.sh
+++ b/aosvc-python/uninstall_mac.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -xe
+
+launch_config_dir="$HOME/Library/LaunchAgents"
+launch_config_path="$launch_config_dir/com.github.ilyatbn.aws_alwayson.plist"
+service_path="$HOME/.local/share/aosvc/bin"
+
+launchctl unload "$launch_config_path"
+rm -f "$service_path/aosvc" "$launch_config_path"


### PR DESCRIPTION
This is only for being able to launch the service in MacOS. The idea is very similar to the one for Linux but using `Launchd`

- Add installation/removal scripts
- Add launchd config
- Update Readme accordingly